### PR TITLE
Developed AWS infrastructure using terraform and deploy flask app into it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 exvenv/
 **__pycache__**
+**.terraform

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 exvenv/
+keys/
 **__pycache__**
 **.terraform**

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 exvenv/
 **__pycache__**
-**.terraform
+**.terraform**

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "tfstate-for-locking" # Created & Versioning Enabled Manually.
+    key            = "terraform.tfstate"   # path and name of state file.
+    region         = "eu-south-1"
+    dynamodb_table = "state_table" # name of dynamodb table for State Lock, must have partition key = "LockID"
+    # encrypt = true # by default
+  }
+}

--- a/terraform/deploy_app.sh
+++ b/terraform/deploy_app.sh
@@ -1,0 +1,6 @@
+instance_ip=$(terraform output --raw instance_public_ip)
+cd ../
+scp -o StrictHostKeyChecking=no -i ./keys/ssh_key_aws -r src/ tests/ ./requirements.txt ./docker-compose.yml ./Dockerfile ec2-user@$instance_ip:~
+cd ./terraform
+ssh -i ../keys/ssh_key_aws ec2-user@$instance_ip
+docker-compose up -d

--- a/terraform/deployment.auto.tfvars
+++ b/terraform/deployment.auto.tfvars
@@ -1,0 +1,5 @@
+ami = "ami-0185600d76ba787f4" 
+
+ec2_type = "t3.micro"
+
+region = "eu-south-1"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,0 +1,14 @@
+resource "aws_instance" "application_instance" {
+  ami                         = var.ami
+  instance_type               = var.ec2_type
+  availability_zone           = "${var.region}a"
+  key_name                    = aws_key_pair.ssh_key_variable.key_name
+  vpc_security_group_ids      = [aws_security_group.InstanceSG.id]
+  associate_public_ip_address = true
+  
+  tags = {
+    Name = "Flask-App"
+  }
+
+
+}

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -10,5 +10,14 @@ resource "aws_instance" "application_instance" {
     Name = "Flask-App"
   }
 
-
+  # Install Docker && Docker-compose
+  user_data = <<-EOF
+    #!/bin/bash
+    yum update -y
+    amazon-linux-extras install docker -y
+    service docker start
+    usermod -a -G docker ec2-user
+    curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+    EOF
 }

--- a/terraform/key_pair.tf
+++ b/terraform/key_pair.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "ssh_key_variable" {
+  key_name   = "ssh_key_aws"
+  public_key = var.public_key
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "instance_public_ip" {
+  value = aws_instance.application_instance.public_ip
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0" # Minor version updates are intended to be non-disruptive
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+  profile = "default" # removing this line solve an issue in github actions. # this can be used for different aws accounts
+}

--- a/terraform/sg.tf
+++ b/terraform/sg.tf
@@ -1,0 +1,29 @@
+#-------------------------- Security Group For EC2 Instance --------------------------#
+resource "aws_security_group" "InstanceSG" {
+  name = "Instance_security_group"
+
+  ingress {
+    description = "allow ssh from ALL"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "allow http from All"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,16 @@
+variable "ami" {
+  type = string
+}
+
+variable "ec2_type" {
+  type = string
+}
+
+variable "public_key" {
+  sensitive = true
+}
+
+variable "region" {
+  type = string
+}
+


### PR DESCRIPTION
- Build AWS Infrastructure using terraform.
- Infrastructure includes: EC2, Key_pair, Security Group.
- Deploy flask app on ec2 using deploy_app.sh script.
- ignore private keys.

The reason for choosing simple architecture is for simplicity but I can scale it to three-tier architecture if needed.