### PR TITLE
move installation of docker, compose  ec2 to ci-cd

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -105,6 +105,18 @@ jobs:
         ./copy_app_files.sh
       working-directory: ./terraform
 
+    - name: Install Docker & Docker Compose on EC2
+      if: env.TRIGGER == 'apply'
+      run: |-
+        ssh -i ./keys/ssh_key_aws ec2-user@$instance_ip << EOF
+            yum update -y
+            amazon-linux-extras install docker -y
+            service docker start
+            usermod -a -G docker ec2-user
+            curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+            chmod +x /usr/local/bin/docker-compose
+        EOF
+    
     - name: Deploy Flask-App
       if: env.TRIGGER == 'apply'
       run: |-
@@ -112,3 +124,4 @@ jobs:
             ls -l
             docker-compose up --build -d
         EOF
+      

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -10,14 +10,4 @@ resource "aws_instance" "application_instance" {
     Name = "Flask-App"
   }
 
-  # Install Docker && Docker-compose
-  user_data = <<-EOF
-    #!/bin/bash
-    yum update -y
-    amazon-linux-extras install docker -y
-    service docker start
-    usermod -a -G docker ec2-user
-    curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
-    chmod +x /usr/local/bin/docker-compose
-    EOF
 }


### PR DESCRIPTION
- Move installation of Docker and Docker-compose from EC2 used_data to GitHub workflow.
- The Reason is: using of docker compose command isn't dependent on user data, so on the first time it runs before the installation complete. So it generates an error